### PR TITLE
feature: Ubuntu Server | Netplan Setup

### DIFF
--- a/ubuntu-server/README.md
+++ b/ubuntu-server/README.md
@@ -1,0 +1,22 @@
+# 💻 About this project
+
+I installed **Ubuntu Server 24.04.2 LTS (64-bit)** on an old laptop I had lying around. I wanted to give it a third life: it previously ran Lubuntu (Ubuntu + LXDE) before I formatted it and replaced it with a server-oriented OS.
+
+---
+
+## 💻 Laptop specs
+
+- **Model**: Asus X555LAB (released in 2015)
+- **CPU**: Intel Core i3-5010U (dual-core, 2.00GHz)
+- **RAM**: 4GB DDR3
+- **Storage**: 1TB SSD
+
+---
+
+## 🕰️ A little bit of backstory
+
+This laptop has been with me for over nine years. It went through countless Linux distributions over time: Manjaro, Elementary OS, Linux Mint, Arch Linux, Debian, Ubuntu, ArcoLinux, and so many others.
+
+When I was a teenager, this was my playground for exploring Linux. I learned a lot from configuring and troubleshooting. It was a great learning experience.
+
+After upgrading to a better laptop in 2022, I left this one running Lubuntu but barely touched it again. Now, it's back in action, repurposed as the first physical device in my homelab.

--- a/ubuntu-server/netplan/netplan-setup.md
+++ b/ubuntu-server/netplan/netplan-setup.md
@@ -1,0 +1,20 @@
+# ⚙️ Netplan Setup
+
+This folder contains Netplan configuration files used on my Ubuntu Server laptop.
+
+The laptop runs Ubuntu Server and uses a **Broadcom BCM43142** wireless chipset, which is very difficult to get working on Linux. These configuration files allow network connectivity via USB tethering or Wi-Fi (once the Broadcom drivers are installed).
+
+## Files
+
+- `usb-tethering.yaml`: Configuration for connecting via USB tethering (e.g., using a mobile phone).
+- `wifi-connection.yaml`: Configuration for connecting to a Wi-Fi network after installing Broadcom drivers.
+
+## Usage
+
+Copy the desired file to `/etc/netplan/`, then test and apply the configuration:
+
+```bash
+sudo cp <file>.yaml /etc/netplan/
+sudo netplan try
+sudo netplan apply
+```

--- a/ubuntu-server/netplan/usb-tethering.yaml
+++ b/ubuntu-server/netplan/usb-tethering.yaml
@@ -1,0 +1,6 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enx123456:
+      dhcp4: true

--- a/ubuntu-server/netplan/wifi-connection.yaml
+++ b/ubuntu-server/netplan/wifi-connection.yaml
@@ -1,0 +1,9 @@
+network:
+  version: 2
+  renderer: NetworkManager
+  wifis:
+    wlp3s0:
+      dhcp4: true
+      access-points:
+        "WifiName Example":
+          password: "123456example"


### PR DESCRIPTION
# Summary
In this branch, I incorporated `ubuntu-server`, the first project of my homelab. The only feature (for now) is `netplan-setup`, where I share the files I used to connect to USB tethering and to WiFi. The first step was necessary, as I didn't had an Ethernet cable and my laptop has a very problematic wireless chipset on Linux. 

## Things done:
- Added the main `README.md`
- Added `netplan-setup`, with .yaml files with example names to not expose the real variables, as well as a `.md` file explaining a little bit about it. 